### PR TITLE
Clean up prod branch differences

### DIFF
--- a/captain-definition
+++ b/captain-definition
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 2,
+  "dockerfilePath": "task_queue/Dockerfile_dev"
+}

--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -25,4 +25,4 @@ WORKDIR /fastapi_app
 EXPOSE 5001
 
 # run the app server, the last argument match the app variable in the webapp.py file
-CMD ["uvicorn", "webapp:app", "--host", "0.0.0.0", "--port", "5001", "--proxy-headers"]
+CMD ["gunicorn", "webapp:app", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:5001", "--workers", "4"]

--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -22,4 +22,4 @@ WORKDIR /fastapi_app
 EXPOSE 5001
 
 # run the app server, the last argument match the app variable in the webapp.py file
-CMD ["gunicorn", "webapp:app", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:5001", "--workers", "4"]
+CMD ["gunicorn", "webapp:app", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:5001", "--workers", "4", "--access-logfile","-","--log-level","info"]

--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -25,4 +25,4 @@ WORKDIR /fastapi_app
 EXPOSE 5001
 
 # run the app server, the last argument match the app variable in the webapp.py file
-CMD ["uvicorn", "fastapi_app.webapp:app", "--host", "0.0.0.0", "--port", "5001", "--proxy-headers"]
+CMD ["uvicorn", "webapp:app", "--host", "0.0.0.0", "--port", "5001", "--proxy-headers"]

--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -1,7 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn:python3.10
-
-ENV CELERY_BROKER_URL redis://redis:6379/0
-ENV CELERY_RESULT_BACKEND redis://redis:6379/0
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
 
 COPY fastapi_app/requirements.txt /tmp/
 

--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -1,11 +1,11 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8
+FROM tiangolo/uvicorn-gunicorn:python3.10
 
 ARG mvs_version
 
 ENV CELERY_BROKER_URL redis://redis:6379/0
 ENV CELERY_RESULT_BACKEND redis://redis:6379/0
 
-COPY requirements.txt /tmp/
+COPY fastapi_app/requirements.txt /tmp/
 
 # install requirements
 RUN python -m pip install --upgrade pip
@@ -15,7 +15,7 @@ RUN pip install multi-vector-simulator==$mvs_version gunicorn
 
 
 
-COPY . /fastapi_app
+COPY fastapi_app/ /fastapi_app
 
 # avoid running as root user
 RUN useradd --create-home appuser
@@ -27,4 +27,4 @@ WORKDIR /fastapi_app
 EXPOSE 5001
 
 # run the app server, the last argument match the app variable in the webapp.py file
-CMD ["uvicorn", "webapp:app", "--host", "0.0.0.0", "--port", "5001", "--proxy-headers"]
+CMD ["uvicorn", "fastapi_app.webapp:app", "--host", "0.0.0.0", "--port", "5001", "--proxy-headers"]

--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -1,7 +1,5 @@
 FROM tiangolo/uvicorn-gunicorn:python3.10
 
-ARG mvs_version
-
 ENV CELERY_BROKER_URL redis://redis:6379/0
 ENV CELERY_RESULT_BACKEND redis://redis:6379/0
 
@@ -11,7 +9,7 @@ COPY fastapi_app/requirements.txt /tmp/
 RUN python -m pip install --upgrade pip
 RUN pip install -r /tmp/requirements.txt
 # install multi-vector-simulator's version pinned in docker-compose.yml file
-RUN pip install multi-vector-simulator==$mvs_version gunicorn
+RUN pip install multi-vector-simulator==1.0.7rc3 gunicorn
 
 
 

--- a/task_queue/Dockerfile_dev
+++ b/task_queue/Dockerfile_dev
@@ -1,8 +1,6 @@
 FROM python:3.10-slim
 
 
-ENV CELERY_BROKER_URL srv-captain--mvs-server-redis
-ENV CELERY_RESULT_BACKEND srv-captain--mvs-server-redis
 
 RUN apt-get update && \
     apt-get install -y git && \
@@ -14,7 +12,7 @@ COPY task_queue/requirements.txt /tmp/
 RUN python -m pip install --upgrade pip
 RUN pip install -r /tmp/requirements.txt
 # install multi-vector-simulator's version pinned in docker-compose.yml file
-RUN pip install multi-vector-simulator==1.0.7rc3 importlib-metadata==4.13.0
+RUN pip install multi-vector-simulator==1.0.7rc3 importlib-metadata==4.13.0 oemof.network==0.5.0a5
 
 run echo $(pip freeze)
 COPY task_queue/ /queue

--- a/task_queue/Dockerfile_dev
+++ b/task_queue/Dockerfile_dev
@@ -1,8 +1,8 @@
 FROM python:3.10-slim
 
 
-ENV CELERY_BROKER_URL redis://redis:6379/0
-ENV CELERY_RESULT_BACKEND redis://redis:6379/0
+ENV CELERY_BROKER_URL srv-captain--mvs-server-redis
+ENV CELERY_RESULT_BACKEND srv-captain--mvs-server-redis
 
 RUN apt-get update && \
     apt-get install -y git && \

--- a/task_queue/Dockerfile_dev
+++ b/task_queue/Dockerfile_dev
@@ -1,8 +1,5 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 
-ARG mvs_version
-
-ENV MVS_VERSION $mvs_version
 
 ENV CELERY_BROKER_URL redis://redis:6379/0
 ENV CELERY_RESULT_BACKEND redis://redis:6379/0
@@ -12,15 +9,15 @@ RUN apt-get update && \
     apt-get install coinor-cbc -y && \
     apt-get install graphviz -y
 
-COPY requirements.txt /tmp/
+COPY task_queue/requirements.txt /tmp/
 
 RUN python -m pip install --upgrade pip
 RUN pip install -r /tmp/requirements.txt
 # install multi-vector-simulator's version pinned in docker-compose.yml file
-RUN pip install multi-vector-simulator==$MVS_VERSION importlib-metadata==4.13.0
+RUN pip install multi-vector-simulator==1.0.7rc3 importlib-metadata==4.13.0
 
 run echo $(pip freeze)
-COPY . /queue
+COPY task_queue/ /queue
 
 # avoid running as root user
 RUN useradd --create-home appuser


### PR DESCRIPTION
Due to different hotfixes the branches `feature/caprover` and `feature/caprover-worker` have diverged, even though they should both be equal and only differ in their `captain-definition` files pointing to the respective Dockerfile. This makes the code harder to maintain and debug. This PR is to get the main branch to the same state / combine the changes made in the branches into one `prod` branch. 